### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 install:
   - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
         }
     ],
     "require": {
+        "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Php55FunctionsTest.php
+++ b/tests/Php55FunctionsTest.php
@@ -1,6 +1,10 @@
 <?php
 
-class Php55FunctionsTest extends PHPUnit\Framework\TestCase
+namespace Ahc\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class Php55FunctionsTest extends TestCase
 {
     /** @dataProvider array_column_data */
     public function test_array_column($message, ...$parameters)
@@ -29,9 +33,9 @@ class Php55FunctionsTest extends PHPUnit\Framework\TestCase
      */
     public function test_array_column_invalid_param2()
     {
-        $this->assertNull(@\Ahc\array_column([], new DateTime));
+        $this->assertNull(@\Ahc\array_column([], new \DateTime));
 
-        \Ahc\array_column([], new stdClass);
+        \Ahc\array_column([], new \stdClass);
     }
 
     /**
@@ -40,9 +44,9 @@ class Php55FunctionsTest extends PHPUnit\Framework\TestCase
      */
     public function test_array_column_invalid_param3()
     {
-        $this->assertNull(@\Ahc\array_column([], null, new DateTime));
+        $this->assertNull(@\Ahc\array_column([], null, new \DateTime));
 
-        \Ahc\array_column([], null, new stdClass);
+        \Ahc\array_column([], null, new \stdClass);
     }
 
     public function array_column_data()


### PR DESCRIPTION
# Changed log
- Add the `php-7.2` and `nightly` test in Travis CI build.
- Add the test namespace defined in the `autoload-dev` of `composer.json`.
- Add more test. Add the `errorHandler` and `assertError` to assert the `trigger_error` with `E_USER_WARNING`.
- Add the `\` before the native PHP classes.